### PR TITLE
Add AI-assisted resume builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+gethired/
 
 *.pyc
 __pycache__/

--- a/ai/llm_io.py
+++ b/ai/llm_io.py
@@ -37,6 +37,28 @@ class LLM:
         response = chat_session.send_message(question)
         return response.text
 
+    def generate_field(self, field_name: str, instructions: str) -> str:
+        """Generate resume text for a specific field using natural language instructions."""
+        genai.configure(api_key=self.api_key)
+        generation_config = {
+            "temperature": 1,
+            "top_p": 0.95,
+            "top_k": 40,
+            "max_output_tokens": 8192,
+        }
+        system_prompt = (
+            f"You are a professional resume writer. Generate the {field_name} "
+            f"using the user's notes. Return only the plain text or bullet list."
+        )
+        model = genai.GenerativeModel(
+            model_name=self.model,
+            system_instruction=system_prompt,
+            generation_config=generation_config,
+        )
+        chat_session = model.start_chat(history=[])
+        response = chat_session.send_message(instructions)
+        return response.text.strip()
+
     """def prompt(self, question: str):
         print(self.model)
         self.model=os.getenv("OLLAMA_MODEL")

--- a/flaskr/routes/main.py
+++ b/flaskr/routes/main.py
@@ -92,14 +92,27 @@ def create_resume():
         'secoes': []
     }
 
-    if data.get('summary'):
+    llm = LLM()
+
+    summary_text = data.get('summary', '')
+    if data.get('use_ai_summary') and summary_text:
+        summary_text = llm.generate_field('professional summary', summary_text)
+    if summary_text:
         cv_data['secoes'].append({
             'titulo': 'Summary',
             'type': 'lista_simples',
-            'itens': [data['summary']]
+            'itens': [summary_text]
         })
 
-    skills = data.get('skills', [])
+    skills_raw = data.get('skills', '')
+    if data.get('use_ai_skills') and skills_raw:
+        skills_generated = llm.generate_field('skills list', skills_raw)
+        skills = [s.strip() for s in skills_generated.replace('\n', ',').split(',') if s.strip()]
+    else:
+        if isinstance(skills_raw, list):
+            skills = skills_raw
+        else:
+            skills = [s.strip() for s in skills_raw.split(',') if s.strip()]
     if skills:
         cv_data['secoes'].append({
             'titulo': 'Skills',
@@ -111,12 +124,16 @@ def create_resume():
     if experiences:
         entries = []
         for exp in experiences:
+            desc = exp.get('description', '')
+            if exp.get('use_ai') and desc:
+                desc = llm.generate_field('job experience description', desc)
+            highlights = [d.strip() for d in desc.split('\n') if d.strip()] if desc else []
             entries.append({
                 'data': exp.get('period', ''),
                 'titulo': exp.get('title', ''),
                 'subtitulo': exp.get('company', ''),
                 'local': exp.get('location', ''),
-                'destaques': [exp.get('description', '')] if exp.get('description') else []
+                'destaques': highlights
             })
         cv_data['secoes'].append({
             'titulo': 'Experience',
@@ -128,12 +145,16 @@ def create_resume():
     if education:
         entries = []
         for ed in education:
+            desc = ed.get('description', '')
+            if ed.get('use_ai') and desc:
+                desc = llm.generate_field('educational experience description', desc)
+            highlights = [d.strip() for d in desc.split('\n') if d.strip()] if desc else []
             entries.append({
                 'data': ed.get('period', ''),
                 'titulo': ed.get('degree', ''),
                 'subtitulo': ed.get('institution', ''),
                 'local': ed.get('field_of_study', ''),
-                'destaques': [ed.get('description', '')] if ed.get('description') else []
+                'destaques': highlights
             })
         cv_data['secoes'].append({
             'titulo': 'Education',

--- a/flaskr/static/resume_builder.js
+++ b/flaskr/static/resume_builder.js
@@ -6,7 +6,8 @@ function createExperienceFields() {
         <input type="text" placeholder="Title" class="title">
         <input type="text" placeholder="Company" class="company">
         <input type="text" placeholder="Location" class="location">
-        <textarea placeholder="Description" class="description"></textarea>
+        <textarea placeholder="Description or AI notes" class="description"></textarea>
+        <label><input type="checkbox" class="use-ai"> Use AI</label>
     `;
     return wrapper;
 }
@@ -23,7 +24,8 @@ function createEducationFields() {
         <input type="text" placeholder="Degree" class="degree">
         <input type="text" placeholder="Institution" class="institution">
         <input type="text" placeholder="Field of Study" class="field">
-        <textarea placeholder="Description" class="description"></textarea>
+        <textarea placeholder="Description or AI notes" class="description"></textarea>
+        <label><input type="checkbox" class="use-ai"> Use AI</label>
     `;
     return wrapper;
 }
@@ -55,6 +57,7 @@ function gatherData() {
             company: item.querySelector('.company').value,
             location: item.querySelector('.location').value,
             description: item.querySelector('.description').value,
+            use_ai: item.querySelector('.use-ai').checked,
         });
     });
 
@@ -66,6 +69,7 @@ function gatherData() {
             institution: item.querySelector('.institution').value,
             field_of_study: item.querySelector('.field').value,
             description: item.querySelector('.description').value,
+            use_ai: item.querySelector('.use-ai').checked,
         });
     });
 
@@ -82,7 +86,9 @@ function gatherData() {
         email: document.getElementById('email').value,
         phone: document.getElementById('phone').value,
         summary: document.getElementById('summary').value,
-        skills: document.getElementById('skills').value.split(',').map(s => s.trim()).filter(s => s),
+        use_ai_summary: document.getElementById('summary_ai').checked,
+        skills: document.getElementById('skills').value,
+        use_ai_skills: document.getElementById('skills_ai').checked,
         experiences: experiences,
         education: education,
         languages: languages

--- a/flaskr/templates/resume_builder.html
+++ b/flaskr/templates/resume_builder.html
@@ -28,10 +28,12 @@
         <div>
             <label>Summary</label>
             <textarea id="summary" rows="4"></textarea>
+            <label><input type="checkbox" id="summary_ai"> Use AI</label>
         </div>
         <div>
-            <label>Skills (comma separated)</label>
+            <label>Skills (comma separated or notes for AI)</label>
             <input type="text" id="skills">
+            <label><input type="checkbox" id="skills_ai"> Use AI</label>
         </div>
         <div id="experienceContainer">
             <h2>Experience</h2>


### PR DESCRIPTION
## Summary
- allow summary and skills to be generated with AI
- allow experience and education descriptions to be generated with AI
- add `generate_field` helper in `LLM`
- ignore local venv directory
- refine AI generation to avoid contaminated system prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b0fed2e908326bfc7629dba87ecc3