### PR TITLE
Add multi-step resume builder with AI text generation

### DIFF
--- a/flaskr/templates/resume_builder_en.html
+++ b/flaskr/templates/resume_builder_en.html
@@ -55,46 +55,84 @@
             <p class="text-gray-600 mb-8">Fill the form below and generate a professional resume.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
-                    <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Location</label>
+                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Phone</label>
+                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
+                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
+                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Website/Portfolio</label>
+                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Summary</label>
+                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Generate with AI (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-end">
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Next</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Location</label>
-                    <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Skills (comma separated or notes for AI)</label>
+                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Generate with AI (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Back</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Next</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                    <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="experienceContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Experience</h2>
+                        <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Add experience</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Back</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Next</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Phone</label>
-                    <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="educationContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Education</h2>
+                        <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Add education</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Back</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Next</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Summary</label>
-                    <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="summary_ai" class="mr-2"> Use AI</label>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Skills (comma separated or notes for AI)</label>
-                    <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="skills_ai" class="mr-2"> Use AI</label>
-                </div>
-                <div id="experienceContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Experience</h2>
-                    <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Add experience</button>
-                </div>
-                <div id="educationContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Education</h2>
-                    <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Add education</button>
-                </div>
-                <div id="languageContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Languages</h2>
-                    <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Add language</button>
-                </div>
-                <div>
-                    <button id="generateBtn" type="submit" class="w-full bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Generate with AI (0)</button>
+                <div class="form-step space-y-6 hidden">
+                    <div id="languageContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Languages</h2>
+                        <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Add language</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Back</button>
+                        <button id="generateBtn" type="submit" class="bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Generate Resume</button>
+                    </div>
                 </div>
             </form>
         </div>

--- a/flaskr/templates/resume_builder_es.html
+++ b/flaskr/templates/resume_builder_es.html
@@ -55,46 +55,84 @@
             <p class="text-gray-600 mb-8">Completa el formulario y genera un currículum profesional.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
-                    <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
+                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Ubicación</label>
+                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Correo</label>
+                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Teléfono</label>
+                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
+                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
+                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Sitio/Portafolio</label>
+                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Resumen</label>
+                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Generar con IA (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-end">
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Siguiente</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Ubicación</label>
-                    <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Habilidades (separadas por comas o notas para IA)</label>
+                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Generar con IA (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Atrás</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Siguiente</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Correo</label>
-                    <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="experienceContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Experiencia</h2>
+                        <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Agregar experiencia</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Atrás</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Siguiente</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Teléfono</label>
-                    <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="educationContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Educación</h2>
+                        <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Agregar educación</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Atrás</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Siguiente</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Resumen</label>
-                    <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="summary_ai" class="mr-2"> Usar IA</label>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Habilidades (separadas por comas o notas para IA)</label>
-                    <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="skills_ai" class="mr-2"> Usar IA</label>
-                </div>
-                <div id="experienceContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Experiencia</h2>
-                    <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Agregar experiencia</button>
-                </div>
-                <div id="educationContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Educación</h2>
-                    <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Agregar educación</button>
-                </div>
-                <div id="languageContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Idiomas</h2>
-                    <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Agregar idioma</button>
-                </div>
-                <div>
-                    <button id="generateBtn" type="submit" class="w-full bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Generar con IA (0)</button>
+                <div class="form-step space-y-6 hidden">
+                    <div id="languageContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Idiomas</h2>
+                        <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Agregar idioma</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Atrás</button>
+                        <button id="generateBtn" type="submit" class="bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Generar CV</button>
+                    </div>
                 </div>
             </form>
         </div>

--- a/flaskr/templates/resume_builder_pt.html
+++ b/flaskr/templates/resume_builder_pt.html
@@ -55,46 +55,84 @@
             <p class="text-gray-600 mb-8">Preencha o formulário abaixo e gere um currículo profissional.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Nome</label>
-                    <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Nome</label>
+                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Localização</label>
+                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
+                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
+                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
+                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Site/Portfólio</label>
+                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Resumo</label>
+                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Gerar com IA (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-end">
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Próximo</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Localização</label>
-                    <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Habilidades (separadas por vírgulas ou notas para IA)</label>
+                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Gerar com IA (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Voltar</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Próximo</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                    <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="experienceContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Experiência</h2>
+                        <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Adicionar experiência</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Voltar</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Próximo</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
-                    <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="educationContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Educação</h2>
+                        <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Adicionar educação</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Voltar</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Próximo</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Resumo</label>
-                    <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="summary_ai" class="mr-2"> Usar IA</label>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Habilidades (separadas por vírgulas ou notas para IA)</label>
-                    <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="skills_ai" class="mr-2"> Usar IA</label>
-                </div>
-                <div id="experienceContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Experiência</h2>
-                    <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Adicionar experiência</button>
-                </div>
-                <div id="educationContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Educação</h2>
-                    <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Adicionar educação</button>
-                </div>
-                <div id="languageContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Idiomas</h2>
-                    <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Adicionar idioma</button>
-                </div>
-                <div>
-                    <button id="generateBtn" type="submit" class="w-full bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Gerar com IA (0)</button>
+                <div class="form-step space-y-6 hidden">
+                    <div id="languageContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Idiomas</h2>
+                        <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Adicionar idioma</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Voltar</button>
+                        <button id="generateBtn" type="submit" class="bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Gerar Currículo</button>
+                    </div>
                 </div>
             </form>
         </div>

--- a/flaskr/templates/resume_builder_ru.html
+++ b/flaskr/templates/resume_builder_ru.html
@@ -55,46 +55,84 @@
             <p class="text-gray-600 mb-8">Заполните форму ниже и создайте профессиональное резюме.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Имя</label>
-                    <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Имя</label>
+                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Местоположение</label>
+                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Телефон</label>
+                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
+                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
+                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Сайт/Портфолио</label>
+                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Резюме</label>
+                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Сгенерировать ИИ (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-end">
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Далее</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Местоположение</label>
-                    <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Навыки (через запятую или заметки для ИИ)</label>
+                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Сгенерировать ИИ (<span class="counter">3</span>)</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Назад</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Далее</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                    <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="experienceContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Опыт работы</h2>
+                        <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Добавить опыт</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Назад</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Далее</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Телефон</label>
-                    <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                <div class="form-step space-y-6 hidden">
+                    <div id="educationContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Образование</h2>
+                        <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Добавить образование</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Назад</button>
+                        <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Далее</button>
+                    </div>
                 </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Резюме</label>
-                    <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="summary_ai" class="mr-2"> Использовать ИИ</label>
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">Навыки (через запятую или заметки для ИИ)</label>
-                    <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <label class="inline-flex items-center mt-2"><input type="checkbox" id="skills_ai" class="mr-2"> Использовать ИИ</label>
-                </div>
-                <div id="experienceContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Опыт работы</h2>
-                    <button type="button" id="addExperience" class="bg-primary text-white px-4 py-2 rounded">Добавить опыт</button>
-                </div>
-                <div id="educationContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Образование</h2>
-                    <button type="button" id="addEducation" class="bg-primary text-white px-4 py-2 rounded">Добавить образование</button>
-                </div>
-                <div id="languageContainer" class="space-y-4">
-                    <h2 class="text-xl font-semibold">Языки</h2>
-                    <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Добавить язык</button>
-                </div>
-                <div>
-                    <button id="generateBtn" type="submit" class="w-full bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Сгенерировать с ИИ (0)</button>
+                <div class="form-step space-y-6 hidden">
+                    <div id="languageContainer" class="space-y-4">
+                        <h2 class="text-xl font-semibold">Языки</h2>
+                        <button type="button" id="addLanguage" class="bg-primary text-white px-4 py-2 rounded">Добавить язык</button>
+                    </div>
+                    <div class="flex justify-between">
+                        <button type="button" class="prev-step bg-gray-500 text-white px-4 py-2 rounded">Назад</button>
+                        <button id="generateBtn" type="submit" class="bg-gradient-to-r from-primary to-secondary text-white font-bold py-4 px-6 rounded-lg hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Создать резюме</button>
+                    </div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- implement multi step resume builder UX in all languages
- add LinkedIn, GitHub and portfolio fields
- allow AI text generation via buttons with limited retries
- update JS to handle steps and generation logic
- update backend to expose `/generate-field` API and handle new fields

## Testing
- `python -m py_compile flaskr/routes/main.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b1d31298c8326aa0f576a98c00707