### PR TITLE
Improve resume builder layout and step navigation

### DIFF
--- a/flaskr/routes/main.py
+++ b/flaskr/routes/main.py
@@ -44,7 +44,6 @@ def transform_json():
     if not cv_text or not vaga_text:
         return jsonify({"erro": "As chaves 'cv' e 'job_description' são obrigatórias."}), 400
 
-    llm = LLM()
     print("LOG: transform_json - Chamando LLM.run()...")
     dados_brutos = llm.run(cv_text, vaga_text)
     print(f"LOG: transform_json - LLM.run() retornou dados brutos (tipo: {type(dados_brutos)}).")
@@ -104,7 +103,6 @@ def create_resume():
         'secoes': []
     }
 
-    llm = LLM()
 
     summary_text = data.get('summary', '')
     if summary_text:

--- a/flaskr/static/resume_builder.js
+++ b/flaskr/static/resume_builder.js
@@ -82,11 +82,23 @@ const steps = Array.from(document.querySelectorAll('.form-step'));
 let currentStep = 0;
 const nextButtons = document.querySelectorAll('.next-step');
 const prevButtons = document.querySelectorAll('.prev-step');
+const stepLinks = document.querySelectorAll('.step-link');
+
+function updateStepNav() {
+    stepLinks.forEach((link, idx) => {
+        const active = idx === currentStep;
+        link.classList.toggle('bg-primary', active);
+        link.classList.toggle('text-white', active);
+        link.classList.toggle('bg-gray-200', !active);
+        link.classList.toggle('text-gray-700', !active);
+    });
+}
 
 function showStep(i) {
     steps.forEach((step, idx) => {
         step.classList.toggle('hidden', idx !== i);
     });
+    updateStepNav();
 }
 
 nextButtons.forEach(btn => btn.addEventListener('click', () => {
@@ -99,6 +111,14 @@ nextButtons.forEach(btn => btn.addEventListener('click', () => {
 prevButtons.forEach(btn => btn.addEventListener('click', () => {
     if (currentStep > 0) {
         currentStep--;
+        showStep(currentStep);
+    }
+}));
+
+stepLinks.forEach(link => link.addEventListener('click', () => {
+    const step = parseInt(link.dataset.step, 10);
+    if (!isNaN(step)) {
+        currentStep = step;
         showStep(currentStep);
     }
 }));

--- a/flaskr/templates/resume_builder_en.html
+++ b/flaskr/templates/resume_builder_en.html
@@ -55,41 +55,48 @@
             <p class="text-gray-600 mb-8">Fill the form below and generate a professional resume.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div class="form-step space-y-6">
-                    <div>
+                <div id="stepNavigation" class="flex justify-center space-x-2 mb-6">
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="0">1</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="1">2</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="2">3</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="3">4</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="4">5</button>
+                </div>
+                <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
                         <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Location</label>
                         <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
                         <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Phone</label>
                         <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
                         <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
                         <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Website/Portfolio</label>
                         <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Summary</label>
                         <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Generate with AI (<span class="counter">3</span>)</button>
                     </div>
-                    <div class="flex justify-end">
+                    <div class="flex justify-end md:col-span-2">
                         <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Next</button>
                     </div>
                 </div>

--- a/flaskr/templates/resume_builder_es.html
+++ b/flaskr/templates/resume_builder_es.html
@@ -55,41 +55,48 @@
             <p class="text-gray-600 mb-8">Completa el formulario y genera un currículum profesional.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div class="form-step space-y-6">
-                    <div>
+                <div id="stepNavigation" class="flex justify-center space-x-2 mb-6">
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="0">1</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="1">2</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="2">3</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="3">4</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="4">5</button>
+                </div>
+                <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
                         <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Ubicación</label>
                         <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Correo</label>
                         <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Teléfono</label>
                         <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
                         <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
                         <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Sitio/Portafolio</label>
                         <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Resumen</label>
                         <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Generar con IA (<span class="counter">3</span>)</button>
                     </div>
-                    <div class="flex justify-end">
+                    <div class="flex justify-end md:col-span-2">
                         <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Siguiente</button>
                     </div>
                 </div>

--- a/flaskr/templates/resume_builder_pt.html
+++ b/flaskr/templates/resume_builder_pt.html
@@ -55,41 +55,48 @@
             <p class="text-gray-600 mb-8">Preencha o formulário abaixo e gere um currículo profissional.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div class="form-step space-y-6">
-                    <div>
+                <div id="stepNavigation" class="flex justify-center space-x-2 mb-6">
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="0">1</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="1">2</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="2">3</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="3">4</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="4">5</button>
+                </div>
+                <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Nome</label>
                         <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Localização</label>
                         <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
                         <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
                         <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
                         <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
                         <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Site/Portfólio</label>
                         <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Resumo</label>
                         <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Gerar com IA (<span class="counter">3</span>)</button>
                     </div>
-                    <div class="flex justify-end">
+                    <div class="flex justify-end md:col-span-2">
                         <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Próximo</button>
                     </div>
                 </div>

--- a/flaskr/templates/resume_builder_ru.html
+++ b/flaskr/templates/resume_builder_ru.html
@@ -55,41 +55,48 @@
             <p class="text-gray-600 mb-8">Заполните форму ниже и создайте профессиональное резюме.</p>
 
             <form id="builderForm" class="space-y-6">
-                <div class="form-step space-y-6">
-                    <div>
+                <div id="stepNavigation" class="flex justify-center space-x-2 mb-6">
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="0">1</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="1">2</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="2">3</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="3">4</button>
+                    <button type="button" class="step-link px-3 py-1 rounded bg-gray-200 text-gray-700" data-step="4">5</button>
+                </div>
+                <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Имя</label>
                         <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Местоположение</label>
                         <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
                         <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Телефон</label>
                         <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
                         <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
                         <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Сайт/Портфолио</label>
                         <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
-                    <div>
+                    <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Резюме</label>
                         <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Сгенерировать ИИ (<span class="counter">3</span>)</button>
                     </div>
-                    <div class="flex justify-end">
+                    <div class="flex justify-end md:col-span-2">
                         <button type="button" class="next-step bg-primary text-white px-4 py-2 rounded">Далее</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove unused LLM call in resume creation route
- add navigation buttons and two-column layout to resume builder pages
- highlight current form step with JS

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b21014d848326979559cdb4382876