### PR TITLE
Implement basic auth with Supabase

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -13,8 +13,15 @@ def create_app():
     app = Flask(__name__)
     CORS(app)
 
+    # Configurações de terceiros
+    app.config['SUPABASE_URL'] = os.environ.get('SUPABASE_URL', '')
+    app.config['SUPABASE_KEY'] = os.environ.get('SUPABASE_KEY', '')
+    app.config['JWT_SECRET'] = os.environ.get('JWT_SECRET', 'change-me')
+
     # Importa e registra as rotas
     from flaskr.routes.main import routes
+    from flaskr.routes.auth import routes_auth
     app.register_blueprint(routes)
+    app.register_blueprint(routes_auth)
 
     return app

--- a/flaskr/auth_utils.py
+++ b/flaskr/auth_utils.py
@@ -1,0 +1,17 @@
+from functools import wraps
+from flask import request, jsonify, current_app
+import jwt
+
+
+def token_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = request.cookies.get('token')
+        if not token:
+            return jsonify({'error': 'token missing'}), 401
+        try:
+            jwt.decode(token, current_app.config['JWT_SECRET'], algorithms=['HS256'])
+        except jwt.PyJWTError:
+            return jsonify({'error': 'invalid token'}), 401
+        return f(*args, **kwargs)
+    return decorated

--- a/flaskr/create_fake_user.py
+++ b/flaskr/create_fake_user.py
@@ -1,0 +1,19 @@
+import os
+from werkzeug.security import generate_password_hash
+from supabase import create_client
+
+url = os.environ.get('SUPABASE_URL')
+key = os.environ.get('SUPABASE_KEY')
+if not url or not key:
+    raise SystemExit('Supabase credentials not configured')
+
+supabase = create_client(url, key)
+
+fake = {
+    'email': 'test@example.com',
+    'password': generate_password_hash('test123'),
+    'name': 'Test User'
+}
+
+supabase.table('users').insert(fake).execute()
+print('Fake user created')

--- a/flaskr/routes/auth.py
+++ b/flaskr/routes/auth.py
@@ -1,0 +1,70 @@
+from flask import Blueprint, request, jsonify, current_app, make_response, render_template
+from werkzeug.security import generate_password_hash, check_password_hash
+import jwt
+from datetime import datetime, timedelta
+
+routes_auth = Blueprint('auth', __name__, url_prefix='/auth')
+
+
+def get_supabase():
+    if not hasattr(current_app, 'supabase'):
+        url = current_app.config.get('SUPABASE_URL')
+        key = current_app.config.get('SUPABASE_KEY')
+        if not url or not key:
+            raise RuntimeError('Supabase credentials not configured')
+        from supabase import create_client
+        current_app.supabase = create_client(url, key)
+    return current_app.supabase
+
+
+@routes_auth.route('/register', methods=['POST'])
+def register():
+    data = request.get_json()
+    if not data or not data.get('email') or not data.get('password'):
+        return jsonify({'error': 'Invalid data'}), 400
+    email = data['email']
+    password = generate_password_hash(data['password'])
+    profile = {
+        'email': email,
+        'password': password,
+        'name': data.get('name', '')
+    }
+    supabase = get_supabase()
+    supabase.table('users').insert(profile).execute()
+    return jsonify({'status': 'registered'})
+
+
+@routes_auth.route('/register', methods=['GET'])
+def register_page():
+    return render_template('register.html')
+
+
+@routes_auth.route('/login', methods=['POST'])
+def login():
+    data = request.get_json()
+    if not data or not data.get('email') or not data.get('password'):
+        return jsonify({'error': 'Invalid data'}), 400
+    supabase = get_supabase()
+    res = supabase.table('users').select('*').eq('email', data['email']).execute()
+    user = res.data[0] if res.data else None
+    if not user or not check_password_hash(user['password'], data['password']):
+        return jsonify({'error': 'Invalid credentials'}), 401
+    token = jwt.encode({'sub': user['email'],
+                        'exp': datetime.utcnow() + timedelta(hours=8)},
+                       current_app.config['JWT_SECRET'], algorithm='HS256')
+    resp = make_response({'status': 'logged_in'})
+    resp.set_cookie('token', token, httponly=True, samesite='Lax')
+    return resp
+
+
+@routes_auth.route('/login', methods=['GET'])
+def login_page():
+    return render_template('login.html')
+
+
+@routes_auth.route('/logout', methods=['POST'])
+def logout():
+    resp = make_response({'status': 'logged_out'})
+    resp.delete_cookie('token')
+    return resp
+

--- a/flaskr/routes/main.py
+++ b/flaskr/routes/main.py
@@ -15,6 +15,7 @@ from ai.llm_io import LLM
 routes = Blueprint("routes", __name__)
 
 from flask import Blueprint, request, send_file, jsonify, render_template, redirect, url_for
+from flaskr.auth_utils import token_required
 
 routes = Blueprint("routes", __name__)
 
@@ -30,6 +31,7 @@ def index(lang_code):
     return render_template(f'index_{lang_code}.html')
 
 @routes.route('/generate', methods=["POST"])
+@token_required
 def transform_json():
     print("LOG: transform_json - Iniciando requisição.")
     dados_entrada = request.get_json()
@@ -100,6 +102,7 @@ def resume_builder(lang_code):
 
 
 @routes.route('/create-resume', methods=['POST'])
+@token_required
 def create_resume():
     """Generate a resume PDF from form data."""
     data = request.get_json()
@@ -201,6 +204,7 @@ def create_resume():
 
 
 @routes.route('/generate-field', methods=['POST'])
+@token_required
 def generate_field_route():
     """Generate text for a single resume field using LLM."""
     data = request.get_json()

--- a/flaskr/static/resume_builder.js
+++ b/flaskr/static/resume_builder.js
@@ -2,11 +2,11 @@ function createExperienceFields() {
     const wrapper = document.createElement('div');
     wrapper.className = 'experience-item space-y-2';
     wrapper.innerHTML = `
-        <input type="text" placeholder="Period" class="period w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Title" class="title w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Company" class="company w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Location" class="location w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <textarea placeholder="Description or AI notes" class="description w-full px-4 py-2 border border-gray-300 rounded-lg"></textarea>
+        <input type="text" placeholder="Period" maxlength="50" class="period w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Title" maxlength="100" class="title w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Company" maxlength="100" class="company w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Location" maxlength="100" class="location w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <textarea placeholder="Description or AI notes" maxlength="500" class="description w-full px-4 py-2 border border-gray-300 rounded-lg"></textarea>
         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded" data-field="job experience description" data-target="description" data-remaining="3">AI (<span class="counter">3</span>)</button>
     `;
     return wrapper;
@@ -20,11 +20,11 @@ function createEducationFields() {
     const wrapper = document.createElement('div');
     wrapper.className = 'education-item space-y-2';
     wrapper.innerHTML = `
-        <input type="text" placeholder="Period" class="period w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Degree" class="degree w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Institution" class="institution w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Field of Study" class="field w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <textarea placeholder="Description or AI notes" class="description w-full px-4 py-2 border border-gray-300 rounded-lg"></textarea>
+        <input type="text" placeholder="Period" maxlength="50" class="period w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Degree" maxlength="100" class="degree w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Institution" maxlength="100" class="institution w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Field of Study" maxlength="100" class="field w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <textarea placeholder="Description or AI notes" maxlength="500" class="description w-full px-4 py-2 border border-gray-300 rounded-lg"></textarea>
         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded" data-field="educational experience description" data-target="description" data-remaining="3">AI (<span class="counter">3</span>)</button>
     `;
     return wrapper;
@@ -38,8 +38,8 @@ function createLanguageFields() {
     const wrapper = document.createElement('div');
     wrapper.className = 'language-item space-y-2';
     wrapper.innerHTML = `
-        <input type="text" placeholder="Language" class="language w-full px-4 py-2 border border-gray-300 rounded-lg">
-        <input type="text" placeholder="Level" class="level w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Language" maxlength="50" class="language w-full px-4 py-2 border border-gray-300 rounded-lg">
+        <input type="text" placeholder="Level" maxlength="50" class="level w-full px-4 py-2 border border-gray-300 rounded-lg">
     `;
     return wrapper;
 }

--- a/flaskr/templates/index_en.html
+++ b/flaskr/templates/index_en.html
@@ -66,6 +66,7 @@
                     </a>
                     <a href="/resume-builder/en" class="text-gray-300 hover:text-primary">CV Generator</a>
                     <a href="/en" class="text-gray-300 hover:text-primary">CV Optimizer</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Account</a>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en" selected>English</option>
                         <option value="pt">Português</option>
@@ -88,9 +89,10 @@
             <form id="cvForm" class="space-y-6">
                 <div>
                     <label for="cvText" class="block text-sm font-medium text-gray-700 mb-2">Your CV (Paste Text)</label>
-                    <textarea 
-                        id="cvText" 
-                        rows="10" 
+                    <textarea
+                        id="cvText"
+                        rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Paste your CV content here..."
                         required
@@ -102,6 +104,7 @@
                     <textarea
                         id="jobDescription"
                         rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Paste the job description here..."
                         required

--- a/flaskr/templates/index_es.html
+++ b/flaskr/templates/index_es.html
@@ -66,6 +66,7 @@
                     </a>
                     <a href="/resume-builder/es" class="text-gray-300 hover:text-primary">Generador de CV</a>
                     <a href="/es" class="text-gray-300 hover:text-primary">Optimizador de CV</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Cuenta</a>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>
@@ -88,9 +89,10 @@
             <form id="cvForm" class="space-y-6">
                 <div>
                     <label for="cvText" class="block text-sm font-medium text-gray-700 mb-2">Tu CV (Pega el Texto)</label>
-                    <textarea 
-                        id="cvText" 
-                        rows="10" 
+                    <textarea
+                        id="cvText"
+                        rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Pega el contenido de tu CV aquí..."
                         required
@@ -102,6 +104,7 @@
                     <textarea
                         id="jobDescription"
                         rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Pega la descripción del puesto aquí..."
                         required

--- a/flaskr/templates/index_pt.html
+++ b/flaskr/templates/index_pt.html
@@ -66,6 +66,7 @@
                     </a>
                     <a href="/resume-builder/pt" class="text-gray-300 hover:text-primary">Gerador de CV</a>
                     <a href="/pt" class="text-gray-300 hover:text-primary">Otimizador de CV</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Conta</a>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt" selected>Português</option>
@@ -88,9 +89,10 @@
             <form id="cvForm" class="space-y-6">
                 <div>
                     <label for="cvText" class="block text-sm font-medium text-gray-700 mb-2">Seu CV (Cole o Texto)</label>
-                    <textarea 
-                        id="cvText" 
-                        rows="10" 
+                    <textarea
+                        id="cvText"
+                        rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Cole o conteúdo do seu CV aqui..."
                         required
@@ -102,6 +104,7 @@
                     <textarea
                         id="jobDescription"
                         rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Cole a descrição da vaga aqui..."
                         required

--- a/flaskr/templates/index_ru.html
+++ b/flaskr/templates/index_ru.html
@@ -66,6 +66,7 @@
                     </a>
                     <a href="/resume-builder/ru" class="text-gray-300 hover:text-primary">Генератор резюме</a>
                     <a href="/ru" class="text-gray-300 hover:text-primary">Оптимизатор резюме</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Аккаунт</a>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>
@@ -88,9 +89,10 @@
             <form id="cvForm" class="space-y-6">
                 <div>
                     <label for="cvText" class="block text-sm font-medium text-gray-700 mb-2">Ваше резюме (вставьте текст)</label>
-                    <textarea 
-                        id="cvText" 
-                        rows="10" 
+                    <textarea
+                        id="cvText"
+                        rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Вставьте содержание вашего резюме здесь..."
                         required
@@ -102,6 +104,7 @@
                     <textarea
                         id="jobDescription"
                         rows="10"
+                        maxlength="8000"
                         class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-all"
                         placeholder="Вставьте описание вакансии здесь..."
                         required

--- a/flaskr/templates/login.html
+++ b/flaskr/templates/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="flex items-center justify-center h-screen bg-gray-100">
+    <form id="loginForm" class="bg-white p-6 rounded shadow-md space-y-4">
+        <h1 class="text-xl font-bold">Login</h1>
+        <input type="email" id="email" maxlength="100" placeholder="Email" class="w-full px-4 py-2 border rounded">
+        <input type="password" id="password" placeholder="Password" class="w-full px-4 py-2 border rounded">
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Login</button>
+    </form>
+<script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const res = await fetch('/auth/login', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({email, password})
+        });
+        if(res.ok){
+            window.location.href = '/';
+        } else {
+            alert('Login failed');
+        }
+    });
+</script>
+</body>
+</html>

--- a/flaskr/templates/register.html
+++ b/flaskr/templates/register.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="flex items-center justify-center h-screen bg-gray-100">
+    <form id="regForm" class="bg-white p-6 rounded shadow-md space-y-4">
+        <h1 class="text-xl font-bold">Register</h1>
+        <input type="text" id="name" maxlength="100" placeholder="Name" class="w-full px-4 py-2 border rounded">
+        <input type="email" id="email" maxlength="100" placeholder="Email" class="w-full px-4 py-2 border rounded">
+        <input type="password" id="password" placeholder="Password" class="w-full px-4 py-2 border rounded">
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Register</button>
+    </form>
+<script>
+    document.getElementById('regForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = {
+            name: document.getElementById('name').value,
+            email: document.getElementById('email').value,
+            password: document.getElementById('password').value
+        };
+        const res = await fetch('/auth/register', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        });
+        if(res.ok){
+            window.location.href = '/auth/login';
+        } else {
+            alert('Registration failed');
+        }
+    });
+</script>
+</body>
+</html>

--- a/flaskr/templates/resume_builder_en.html
+++ b/flaskr/templates/resume_builder_en.html
@@ -37,6 +37,7 @@
                     </a>
                     <a href="/resume-builder/en" class="text-gray-300 hover:text-primary">CV Generator</a>
                     <a href="/en" class="text-gray-300 hover:text-primary">CV Optimizer</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Account</a>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en" selected>English</option>
                         <option value="pt">Português</option>
@@ -67,35 +68,35 @@
                 <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
-                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="name" maxlength="100" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Location</label>
-                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="location" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="email" id="email" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Phone</label>
-                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="phone" maxlength="30" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
-                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="linkedin" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
-                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="github" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Website/Portfolio</label>
-                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="website" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Summary</label>
-                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <textarea id="summary" rows="4" maxlength="1000" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Generate with AI (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-end md:col-span-2">
@@ -105,7 +106,7 @@
                 <div class="form-step space-y-6 hidden">
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1">Skills (comma separated or notes for AI)</label>
-                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="skills" maxlength="500" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Generate with AI (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-between">

--- a/flaskr/templates/resume_builder_es.html
+++ b/flaskr/templates/resume_builder_es.html
@@ -37,6 +37,7 @@
                     </a>
                     <a href="/resume-builder/es" class="text-gray-300 hover:text-primary">Generador de CV</a>
                     <a href="/es" class="text-gray-300 hover:text-primary">Optimizador de CV</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Cuenta</a>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>
@@ -67,35 +68,35 @@
                 <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
-                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="name" maxlength="100" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Ubicación</label>
-                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="location" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Correo</label>
-                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="email" id="email" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Teléfono</label>
-                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="phone" maxlength="30" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
-                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="linkedin" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
-                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="github" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Sitio/Portafolio</label>
-                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="website" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Resumen</label>
-                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <textarea id="summary" maxlength="1000" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Generar con IA (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-end md:col-span-2">
@@ -105,7 +106,7 @@
                 <div class="form-step space-y-6 hidden">
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1">Habilidades (separadas por comas o notas para IA)</label>
-                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="skills" maxlength="500" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Generar con IA (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-between">

--- a/flaskr/templates/resume_builder_pt.html
+++ b/flaskr/templates/resume_builder_pt.html
@@ -37,6 +37,7 @@
                     </a>
                     <a href="/resume-builder/pt" class="text-gray-300 hover:text-primary">Gerador de CV</a>
                     <a href="/pt" class="text-gray-300 hover:text-primary">Otimizador de CV</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Conta</a>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt" selected>Português</option>
@@ -67,35 +68,35 @@
                 <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Nome</label>
-                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="name" maxlength="100" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Localização</label>
-                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="location" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="email" id="email" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
-                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="phone" maxlength="30" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
-                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="linkedin" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
-                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="github" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Site/Portfólio</label>
-                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="website" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Resumo</label>
-                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <textarea id="summary" maxlength="1000" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Gerar com IA (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-end md:col-span-2">
@@ -105,7 +106,7 @@
                 <div class="form-step space-y-6 hidden">
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1">Habilidades (separadas por vírgulas ou notas para IA)</label>
-                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="skills" maxlength="500" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Gerar com IA (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-between">

--- a/flaskr/templates/resume_builder_ru.html
+++ b/flaskr/templates/resume_builder_ru.html
@@ -37,6 +37,7 @@
                     </a>
                     <a href="/resume-builder/ru" class="text-gray-300 hover:text-primary">Генератор резюме</a>
                     <a href="/ru" class="text-gray-300 hover:text-primary">Оптимизатор резюме</a>
+                    <a href="/auth/login" class="text-gray-300 hover:text-primary">Аккаунт</a>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>
@@ -67,35 +68,35 @@
                 <div class="form-step grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Имя</label>
-                        <input type="text" id="name" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="name" maxlength="100" required class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Местоположение</label>
-                        <input type="text" id="location" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="location" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                        <input type="email" id="email" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="email" id="email" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Телефон</label>
-                        <input type="text" id="phone" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="phone" maxlength="30" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn</label>
-                        <input type="text" id="linkedin" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="linkedin" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">GitHub</label>
-                        <input type="text" id="github" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="github" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="col-span-1">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Сайт/Портфолио</label>
-                        <input type="text" id="website" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="website" maxlength="100" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-sm font-medium text-gray-700 mb-1">Резюме</label>
-                        <textarea id="summary" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
+                        <textarea id="summary" maxlength="1000" rows="4" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"></textarea>
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="professional summary" data-target="summary" data-remaining="3">Сгенерировать ИИ (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-end md:col-span-2">
@@ -105,7 +106,7 @@
                 <div class="form-step space-y-6 hidden">
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1">Навыки (через запятую или заметки для ИИ)</label>
-                        <input type="text" id="skills" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
+                        <input type="text" id="skills" maxlength="500" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                         <button type="button" class="ai-generate bg-primary text-white px-4 py-2 rounded mt-2" data-field="skills list" data-target="skills" data-remaining="3">Сгенерировать ИИ (<span class="counter">3</span>)</button>
                     </div>
                     <div class="flex justify-between">

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,6 @@ typing-inspection==0.4.1
 typing_extensions==4.14.1
 urllib3==2.5.0
 Werkzeug==3.1.3
+
+supabase==2.4.3
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- add JWT-based authentication routes and helpers
- integrate Supabase for user registration and login
- protect resume routes with token validation
- add new login and register pages
- add script to create fake user
- enforce reasonable character limits in forms
- update navigation with account link
- include new dependencies

## Testing
- `python -m compileall -q -f .`

------
https://chatgpt.com/codex/tasks/task_e_687b2a264f808326be360f0da886dd5e