### PR TITLE
Implement home page and resume data storage

### DIFF
--- a/create_tables.sql
+++ b/create_tables.sql
@@ -6,3 +6,11 @@ create table if not exists users (
   password text not null,
   name text
 );
+
+-- Stores resume data used to generate LaTeX for each user
+create table if not exists latex_data (
+  id uuid default uuid_generate_v4() primary key,
+  user_email text not null,
+  resume_json jsonb not null,
+  created_at timestamptz default now()
+);

--- a/flaskr/static/auth_nav.js
+++ b/flaskr/static/auth_nav.js
@@ -4,22 +4,25 @@ function getToken(){
 
 function updateNav(){
   const logged = !!getToken();
-  const login = document.getElementById('nav-account');
-  const profile = document.getElementById('nav-profile');
-  const logout = document.getElementById('nav-logout');
+  const login = document.getElementById('account-login');
+  const register = document.getElementById('account-register');
+  const profile = document.getElementById('account-profile');
+  const logout = document.getElementById('account-logout');
   if(logged){
     if(login) login.style.display = 'none';
-    if(profile) profile.style.display = 'inline';
-    if(logout) logout.style.display = 'inline';
+    if(register) register.style.display = 'none';
+    if(profile) profile.style.display = 'block';
+    if(logout) logout.style.display = 'block';
   } else {
-    if(login) login.style.display = 'inline';
+    if(login) login.style.display = 'block';
+    if(register) register.style.display = 'block';
     if(profile) profile.style.display = 'none';
     if(logout) logout.style.display = 'none';
   }
 }
 
 function setupLogout(){
-  const logout = document.getElementById('nav-logout');
+  const logout = document.getElementById('account-logout');
   if(logout){
     logout.addEventListener('click', async (e) => {
       e.preventDefault();
@@ -30,7 +33,24 @@ function setupLogout(){
   }
 }
 
+function setupDropdown(){
+  const btn = document.getElementById('nav-account-btn');
+  const menu = document.getElementById('account-menu');
+  if(btn && menu){
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      menu.classList.toggle('hidden');
+    });
+    document.addEventListener('click', (e) => {
+      if(!btn.contains(e.target) && !menu.contains(e.target)){
+        menu.classList.add('hidden');
+      }
+    });
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   updateNav();
   setupLogout();
+  setupDropdown();
 });

--- a/flaskr/templates/home_en.html
+++ b/flaskr/templates/home_en.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <base target="_self">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get Hired! | Home</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='favicon-32x32.png') }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='favicon-16x16.png') }}">
+    <link rel="manifest" href="{{ url_for('static', filename='site.webmanifest') }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+</head>
+<body class="min-h-screen bg-gray-50 flex flex-col">
+    <header class="bg-gray-800 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <div class="text-2xl font-bold text-white">
+                    <span class="text-primary">Get</span> Hired!
+                </div>
+                <div class="hidden md:flex space-x-8 items-center">
+                    <a href="https://github.com/brunomoraes97/get-hired" target="_blank" class="text-gray-300 hover:text-primary transition-colors flex items-center">
+                        <i class="fab fa-github mr-2"></i> View on GitHub
+                    </a>
+                    <a href="/resume-builder/en" class="text-gray-300 hover:text-primary">CV Generator</a>
+                    <a href="/en" class="text-gray-300 hover:text-primary">CV Optimizer</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Account <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Login</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Register</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
+                    <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
+                        <option value="en" selected>English</option>
+                        <option value="pt">Português</option>
+                        <option value="es">Español</option>
+                        <option value="ru">Русский</option>
+                    </select>
+                </div>
+                <button class="md:hidden text-gray-300">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 flex-grow">
+        <div class="max-w-3xl mx-auto bg-white rounded-xl shadow-md overflow-hidden p-8 text-center">
+            <h1 class="text-3xl font-bold text-gray-800 mb-4">Welcome to Get Hired!</h1>
+            <p class="text-gray-600 mb-8">Generate and optimize your resume with the power of AI.</p>
+            <div class="space-x-4">
+                <a href="/resume-builder/en" class="bg-primary text-white px-4 py-2 rounded hover:opacity-90">Build Resume</a>
+                <a href="/en" class="bg-secondary text-white px-4 py-2 rounded hover:opacity-90">Optimize CV</a>
+            </div>
+        </div>
+    </main>
+
+    <footer class="bg-gray-800 text-white py-8 mt-auto">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col md:flex-row justify-between items-center">
+                <div class="mb-4 md:mb-0">
+                    <div class="text-2xl font-bold">
+                        <span class="text-primary">Get</span><span class="text-white"> Hired!</span>
+                    </div>
+                    <p class="text-gray-400 mt-2">Connecting talent with opportunity</p>
+                </div>
+                <div class="flex space-x-6">
+                    <a href="https://www.linkedin.com/in/brunomoraes97/" class="text-gray-400 hover:text-white transition-colors">
+                        <i class="fab fa-linkedin-in text-xl"></i>
+                    </a>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400 text-sm">
+                <p>© 2025 Get Hired!. All rights reserved. | Made with ❤️ by Matheus Bruno</p>
+            </div>
+        </div>
+    </footer>
+    <script>
+        function changeLanguage(lang){
+            window.location.href = '/home/' + lang;
+        }
+    </script>
+    <script src="{{ url_for('static', filename='auth_nav.js') }}"></script>
+</body>
+</html>

--- a/flaskr/templates/home_es.html
+++ b/flaskr/templates/home_es.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <base target="_self">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get Hired! | Inicio</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='favicon-32x32.png') }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='favicon-16x16.png') }}">
+    <link rel="manifest" href="{{ url_for('static', filename='site.webmanifest') }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+</head>
+<body class="min-h-screen bg-gray-50 flex flex-col">
+    <header class="bg-gray-800 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <div class="text-2xl font-bold text-white">
+                    <span class="text-primary">Get</span> Hired!
+                </div>
+                <div class="hidden md:flex space-x-8 items-center">
+                    <a href="https://github.com/brunomoraes97/get-hired" target="_blank" class="text-gray-300 hover:text-primary transition-colors flex items-center">
+                        <i class="fab fa-github mr-2"></i> Ver en GitHub
+                    </a>
+                    <a href="/resume-builder/es" class="text-gray-300 hover:text-primary">Generador de CV</a>
+                    <a href="/es" class="text-gray-300 hover:text-primary">Optimizar CV</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Cuenta <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Iniciar sesión</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Crear cuenta</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Mis Datos</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Salir</a>
+                        </div>
+                    </div>
+                    <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
+                        <option value="en">English</option>
+                        <option value="pt">Português</option>
+                        <option value="es" selected>Español</option>
+                        <option value="ru">Русский</option>
+                    </select>
+                </div>
+                <button class="md:hidden text-gray-300">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 flex-grow">
+        <div class="max-w-3xl mx-auto bg-white rounded-xl shadow-md overflow-hidden p-8 text-center">
+            <h1 class="text-3xl font-bold text-gray-800 mb-4">¡Bienvenido a Get Hired!</h1>
+            <p class="text-gray-600 mb-8">Genera y optimiza tu currículum con el poder de la IA.</p>
+            <div class="space-x-4">
+                <a href="/resume-builder/es" class="bg-primary text-white px-4 py-2 rounded hover:opacity-90">Crear CV</a>
+                <a href="/es" class="bg-secondary text-white px-4 py-2 rounded hover:opacity-90">Optimizar CV</a>
+            </div>
+        </div>
+    </main>
+
+    <footer class="bg-gray-800 text-white py-8 mt-auto">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col md:flex-row justify-between items-center">
+                <div class="mb-4 md:mb-0">
+                    <div class="text-2xl font-bold">
+                        <span class="text-primary">Get</span><span class="text-white"> Hired!</span>
+                    </div>
+                    <p class="text-gray-400 mt-2">Conectando talento con oportunidad</p>
+                </div>
+                <div class="flex space-x-6">
+                    <a href="https://www.linkedin.com/in/brunomoraes97/" class="text-gray-400 hover:text-white transition-colors">
+                        <i class="fab fa-linkedin-in text-xl"></i>
+                    </a>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400 text-sm">
+                <p>© 2025 Get Hired!. Todos los derechos reservados. | Hecho con ❤️ por Matheus Bruno</p>
+            </div>
+        </div>
+    </footer>
+    <script>
+        function changeLanguage(lang){
+            window.location.href = '/home/' + lang;
+        }
+    </script>
+    <script src="{{ url_for('static', filename='auth_nav.js') }}"></script>
+</body>
+</html>

--- a/flaskr/templates/home_pt.html
+++ b/flaskr/templates/home_pt.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <base target="_self">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get Hired! | Início</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='favicon-32x32.png') }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='favicon-16x16.png') }}">
+    <link rel="manifest" href="{{ url_for('static', filename='site.webmanifest') }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+</head>
+<body class="min-h-screen bg-gray-50 flex flex-col">
+    <header class="bg-gray-800 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <div class="text-2xl font-bold text-white">
+                    <span class="text-primary">Get</span> Hired!
+                </div>
+                <div class="hidden md:flex space-x-8 items-center">
+                    <a href="https://github.com/brunomoraes97/get-hired" target="_blank" class="text-gray-300 hover:text-primary transition-colors flex items-center">
+                        <i class="fab fa-github mr-2"></i> Ver no GitHub
+                    </a>
+                    <a href="/resume-builder/pt" class="text-gray-300 hover:text-primary">Gerador de CV</a>
+                    <a href="/pt" class="text-gray-300 hover:text-primary">Otimizar CV</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Conta <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Login</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Criar Conta</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Meus Dados</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Sair</a>
+                        </div>
+                    </div>
+                    <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
+                        <option value="en">English</option>
+                        <option value="pt" selected>Português</option>
+                        <option value="es">Español</option>
+                        <option value="ru">Русский</option>
+                    </select>
+                </div>
+                <button class="md:hidden text-gray-300">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 flex-grow">
+        <div class="max-w-3xl mx-auto bg-white rounded-xl shadow-md overflow-hidden p-8 text-center">
+            <h1 class="text-3xl font-bold text-gray-800 mb-4">Bem-vindo ao Get Hired!</h1>
+            <p class="text-gray-600 mb-8">Gere e otimize seu currículo com o poder da IA.</p>
+            <div class="space-x-4">
+                <a href="/resume-builder/pt" class="bg-primary text-white px-4 py-2 rounded hover:opacity-90">Criar CV</a>
+                <a href="/pt" class="bg-secondary text-white px-4 py-2 rounded hover:opacity-90">Otimizar CV</a>
+            </div>
+        </div>
+    </main>
+
+    <footer class="bg-gray-800 text-white py-8 mt-auto">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col md:flex-row justify-between items-center">
+                <div class="mb-4 md:mb-0">
+                    <div class="text-2xl font-bold">
+                        <span class="text-primary">Get</span><span class="text-white"> Hired!</span>
+                    </div>
+                    <p class="text-gray-400 mt-2">Conectando talento com oportunidade</p>
+                </div>
+                <div class="flex space-x-6">
+                    <a href="https://www.linkedin.com/in/brunomoraes97/" class="text-gray-400 hover:text-white transition-colors">
+                        <i class="fab fa-linkedin-in text-xl"></i>
+                    </a>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400 text-sm">
+                <p>© 2025 Get Hired!. Todos os direitos reservados. | Feito com ❤️ por Matheus Bruno</p>
+            </div>
+        </div>
+    </footer>
+    <script>
+        function changeLanguage(lang){
+            window.location.href = '/home/' + lang;
+        }
+    </script>
+    <script src="{{ url_for('static', filename='auth_nav.js') }}"></script>
+</body>
+</html>

--- a/flaskr/templates/home_ru.html
+++ b/flaskr/templates/home_ru.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <base target="_self">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get Hired! | Главная</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='apple-touch-icon.png') }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='favicon-32x32.png') }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='favicon-16x16.png') }}">
+    <link rel="manifest" href="{{ url_for('static', filename='site.webmanifest') }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+</head>
+<body class="min-h-screen bg-gray-50 flex flex-col">
+    <header class="bg-gray-800 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <div class="text-2xl font-bold text-white">
+                    <span class="text-primary">Get</span> Hired!
+                </div>
+                <div class="hidden md:flex space-x-8 items-center">
+                    <a href="https://github.com/brunomoraes97/get-hired" target="_blank" class="text-gray-300 hover:text-primary transition-colors flex items-center">
+                        <i class="fab fa-github mr-2"></i> Смотреть на GitHub
+                    </a>
+                    <a href="/resume-builder/ru" class="text-gray-300 hover:text-primary">Генератор резюме</a>
+                    <a href="/ru" class="text-gray-300 hover:text-primary">Оптимизатор CV</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Аккаунт <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Войти</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Создать аккаунт</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Мои данные</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Выйти</a>
+                        </div>
+                    </div>
+                    <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
+                        <option value="en">English</option>
+                        <option value="pt">Português</option>
+                        <option value="es">Español</option>
+                        <option value="ru" selected>Русский</option>
+                    </select>
+                </div>
+                <button class="md:hidden text-gray-300">
+                    <i class="fas fa-bars text-xl"></i>
+                </button>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 flex-grow">
+        <div class="max-w-3xl mx-auto bg-white rounded-xl shadow-md overflow-hidden p-8 text-center">
+            <h1 class="text-3xl font-bold text-gray-800 mb-4">Добро пожаловать в Get Hired!</h1>
+            <p class="text-gray-600 mb-8">Создавайте и улучшайте свое резюме с помощью ИИ.</p>
+            <div class="space-x-4">
+                <a href="/resume-builder/ru" class="bg-primary text-white px-4 py-2 rounded hover:opacity-90">Создать резюме</a>
+                <a href="/ru" class="bg-secondary text-white px-4 py-2 rounded hover:opacity-90">Оптимизировать CV</a>
+            </div>
+        </div>
+    </main>
+
+    <footer class="bg-gray-800 text-white py-8 mt-auto">
+        <div class="container mx-auto px-6">
+            <div class="flex flex-col md:flex-row justify-between items-center">
+                <div class="mb-4 md:mb-0">
+                    <div class="text-2xl font-bold">
+                        <span class="text-primary">Get</span><span class="text-white"> Hired!</span>
+                    </div>
+                    <p class="text-gray-400 mt-2">Соединяем талант с возможностями</p>
+                </div>
+                <div class="flex space-x-6">
+                    <a href="https://www.linkedin.com/in/brunomoraes97/" class="text-gray-400 hover:text-white transition-colors">
+                        <i class="fab fa-linkedin-in text-xl"></i>
+                    </a>
+                </div>
+            </div>
+            <div class="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400 text-sm">
+                <p>© 2025 Get Hired!. Все права защищены. | Сделано с ❤️ Матэусом Бруно</p>
+            </div>
+        </div>
+    </footer>
+    <script>
+        function changeLanguage(lang){
+            window.location.href = '/home/' + lang;
+        }
+    </script>
+    <script src="{{ url_for('static', filename='auth_nav.js') }}"></script>
+</body>
+</html>

--- a/flaskr/templates/index_en.html
+++ b/flaskr/templates/index_en.html
@@ -66,9 +66,15 @@
                     </a>
                     <a href="/resume-builder/en" class="text-gray-300 hover:text-primary">CV Generator</a>
                     <a href="/en" class="text-gray-300 hover:text-primary">CV Optimizer</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Account</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Account <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Login</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Register</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en" selected>English</option>
                         <option value="pt">Português</option>

--- a/flaskr/templates/index_es.html
+++ b/flaskr/templates/index_es.html
@@ -66,9 +66,15 @@
                     </a>
                     <a href="/resume-builder/es" class="text-gray-300 hover:text-primary">Generador de CV</a>
                     <a href="/es" class="text-gray-300 hover:text-primary">Optimizador de CV</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Cuenta</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Cuenta <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Iniciar sesión</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Crear cuenta</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>

--- a/flaskr/templates/index_pt.html
+++ b/flaskr/templates/index_pt.html
@@ -66,9 +66,15 @@
                     </a>
                     <a href="/resume-builder/pt" class="text-gray-300 hover:text-primary">Gerador de CV</a>
                     <a href="/pt" class="text-gray-300 hover:text-primary">Otimizador de CV</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Conta</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Conta <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Login</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Criar Conta</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt" selected>Português</option>

--- a/flaskr/templates/index_ru.html
+++ b/flaskr/templates/index_ru.html
@@ -66,9 +66,15 @@
                     </a>
                     <a href="/resume-builder/ru" class="text-gray-300 hover:text-primary">Генератор резюме</a>
                     <a href="/ru" class="text-gray-300 hover:text-primary">Оптимизатор резюме</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Аккаунт</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Аккаунт <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Войти</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Создать аккаунт</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="lang-select" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>

--- a/flaskr/templates/resume_builder_en.html
+++ b/flaskr/templates/resume_builder_en.html
@@ -37,9 +37,15 @@
                     </a>
                     <a href="/resume-builder/en" class="text-gray-300 hover:text-primary">CV Generator</a>
                     <a href="/en" class="text-gray-300 hover:text-primary">CV Optimizer</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Account</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Account <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Login</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Register</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en" selected>English</option>
                         <option value="pt">Português</option>

--- a/flaskr/templates/resume_builder_es.html
+++ b/flaskr/templates/resume_builder_es.html
@@ -37,9 +37,15 @@
                     </a>
                     <a href="/resume-builder/es" class="text-gray-300 hover:text-primary">Generador de CV</a>
                     <a href="/es" class="text-gray-300 hover:text-primary">Optimizador de CV</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Cuenta</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Cuenta <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Iniciar sesión</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Crear cuenta</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>

--- a/flaskr/templates/resume_builder_pt.html
+++ b/flaskr/templates/resume_builder_pt.html
@@ -37,9 +37,15 @@
                     </a>
                     <a href="/resume-builder/pt" class="text-gray-300 hover:text-primary">Gerador de CV</a>
                     <a href="/pt" class="text-gray-300 hover:text-primary">Otimizador de CV</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Conta</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Conta <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Login</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Criar Conta</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt" selected>Português</option>

--- a/flaskr/templates/resume_builder_ru.html
+++ b/flaskr/templates/resume_builder_ru.html
@@ -37,9 +37,15 @@
                     </a>
                     <a href="/resume-builder/ru" class="text-gray-300 hover:text-primary">Генератор резюме</a>
                     <a href="/ru" class="text-gray-300 hover:text-primary">Оптимизатор резюме</a>
-                    <a href="/auth/login" class="text-gray-300 hover:text-primary" id="nav-account">Аккаунт</a>
-                    <a href="/auth/me" class="text-gray-300 hover:text-primary" id="nav-profile" style="display:none">My Data</a>
-                    <a href="#" class="text-gray-300 hover:text-primary" id="nav-logout" style="display:none">Logout</a>
+                    <div class="relative" id="account-dropdown">
+                        <button id="nav-account-btn" class="text-gray-300 hover:text-primary flex items-center">Аккаунт <i class="fas fa-caret-down ml-1"></i></button>
+                        <div id="account-menu" class="absolute right-0 mt-2 w-40 bg-white rounded-md shadow-lg py-1 hidden">
+                            <a href="/auth/login" id="account-login" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Войти</a>
+                            <a href="/auth/register" id="account-register" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">Создать аккаунт</a>
+                            <a href="/auth/me" id="account-profile" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">My Data</a>
+                            <a href="#" id="account-logout" class="block px-4 py-2 text-gray-700 hover:bg-gray-100" style="display:none">Logout</a>
+                        </div>
+                    </div>
                     <select id="language-selector" class="bg-gray-700 text-white border border-gray-600 p-2 rounded" onchange="changeLanguage(this.value)">
                         <option value="en">English</option>
                         <option value="pt">Português</option>


### PR DESCRIPTION
## Summary
- add a table to store LaTeX resume data
- refactor routes to include new home page
- insert resume data into Supabase when creating resumes
- implement account dropdown menu and update JS helpers
- add localized home pages for all languages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3da8fc8483269c4d343e25fd05c4